### PR TITLE
Add .dockerignore file to avoid copying unwanted files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+Dockerfile
+README.md
+.dockerignore
+.git
+.gitignore


### PR DESCRIPTION
Avoid copying e.g. the Dockerfile to the container.