### PR TITLE
Prevent from being used in iframe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN mkdir /target && \
 # Serve the generated html using nginx
 FROM nginxinc/nginx-unprivileged:alpine
 RUN sed -i '3 a\    absolute_redirect off;' /etc/nginx/conf.d/default.conf && \
+    sed -i '4 a\    add_header X-Frame-Options DENY always;' /etc/nginx/conf.d/default.conf && \
     sed -i 's/#error_page  404/error_page  404/' /etc/nginx/conf.d/default.conf
 COPY --from=build /target /usr/share/nginx/html
 


### PR DESCRIPTION
Currently, `dsw-appendix.scilifelab.se` can be used in a iframe in any sites.

The added `ngnix` configuration will prevent it from being rendered in any `iframe` in any site.