### PR TITLE
Setup pa11y for accessibility test

### DIFF
--- a/.github/sitemap.xml
+++ b/.github/sitemap.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset
+      xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
+            http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
+<!-- created with Free Online Sitemap Generator www.xml-sitemaps.com -->
+
+
+<url>
+  <loc>https://dsw-appendix.scilifelab.se/</loc>
+  <lastmod>2023-11-21T10:12:32+00:00</lastmod>
+  <priority>1.00</priority>
+</url>
+<url>
+  <loc>https://dsw-appendix.scilifelab.se/privacy/</loc>
+  <lastmod>2023-11-21T10:12:32+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://dsw-appendix.scilifelab.se/contact/</loc>
+  <lastmod>2023-11-21T10:12:32+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://dsw-appendix.scilifelab.se/dmp-guide/new-project/</loc>
+  <lastmod>2023-11-21T10:12:32+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://dsw-appendix.scilifelab.se/dmp-guide/answer-questions/</loc>
+  <lastmod>2023-11-21T10:12:32+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://dsw-appendix.scilifelab.se/dmp-guide/export-project/</loc>
+  <lastmod>2023-11-21T10:12:32+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://dsw-appendix.scilifelab.se/dmp-guide/collaborate-project/</loc>
+  <lastmod>2023-11-21T10:12:32+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://dsw-appendix.scilifelab.se/dmp-guide/migrate-project/</loc>
+  <lastmod>2023-11-21T10:12:32+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://dsw-appendix.scilifelab.se/dmp-guide/clone-project/</loc>
+  <lastmod>2023-11-21T10:12:32+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://dsw-appendix.scilifelab.se/dmp-guide/help-feedback/</loc>
+  <lastmod>2023-11-21T10:12:32+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://dsw-appendix.scilifelab.se/checklist-guide/</loc>
+  <lastmod>2023-11-21T10:12:32+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://dsw-appendix.scilifelab.se/dmp-guide/useful-tricks/</loc>
+  <lastmod>2023-11-21T10:12:32+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://dsw-appendix.scilifelab.se/project-templates/</loc>
+  <lastmod>2023-11-21T10:12:32+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://dsw-appendix.scilifelab.se/knowledge-models/</loc>
+  <lastmod>2023-11-21T10:12:32+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+<url>
+  <loc>https://dsw-appendix.scilifelab.se/dmp-guide/</loc>
+  <lastmod>2023-11-21T10:12:32+00:00</lastmod>
+  <priority>0.80</priority>
+</url>
+
+
+</urlset>

--- a/.github/workflows/pa11y_test.yaml
+++ b/.github/workflows/pa11y_test.yaml
@@ -1,0 +1,33 @@
+# Pa11y: A tool to check accessibility issue on a webpage
+# The config file and sitemap file used by this workflow
+# is in the ".github" directory of the repositiory
+#
+# This workflow is configured to run firest wednesday of
+# the month at 09:30.
+# It can also be run manually from repo's Gihthub page
+#----------------------------------------------------------------
+
+name: Pa11ly Accessibitly Check
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '30 9 1-7 * WED'
+
+jobs:
+    pa11ly:
+        name: Pa11ly Test
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check out the repo
+              uses: actions/checkout@v4
+
+            - name: Set up Node.js 22.x
+              uses: actions/setup-node@v4
+              with:
+                node-version: 22.x
+            
+            - name: Install Pa11ly CI
+              run: npm install -g pa11y-ci
+            
+            - name: Run Pa11ly CI
+              run: pa11y-ci --sitemap https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/develop/.github/sitemap.xml

--- a/.github/workflows/pa11y_test.yaml
+++ b/.github/workflows/pa11y_test.yaml
@@ -7,7 +7,7 @@
 # It can also be run manually from repo's Gihthub page
 #----------------------------------------------------------------
 
-name: Pa11ly Accessibitly Check
+name: Pa11ly Accessibility Check
 on:
   workflow_dispatch:
   schedule:

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="UTF-8">
     <title>Data Stewardship Wizard</title>


### PR DESCRIPTION
This PR is to setup `pa11y` workflow, so on every Friday at 12:30 a github action is run to check for any accessibility issue at `dsw-appendix.scilifelab.se`.

The site considerably small and it had only one issue i.e. missing `lang` in the `<html>` tag. That is also fixed in this PR. So the site has to be re-deployed after this PR is merged.

This is already set up in [data platform](https://github.com/ScilifelabDataCentre/data.scilifelab.se/actions/workflows/pa11y_test.yaml). Since this site did not have any specific issues, we **don't need** a `pa11y.config` yet.