### PR TITLE
FREYA-1151: Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @ScilifelabDataCentre/teamfreya
+/content/ @YvonneKallberg


### PR DESCRIPTION
- Add both Team Freya and Yvonne as code owners for all files.

Here we could also do a more specific rule for file types or particular directories (as per [here](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file)). 
i.e. are there certain file types/locations which always require Yvonne's review or someone from Freya's review? 