### PR TITLE
FREYA-1182: Update LICENSE: add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -18,6 +18,30 @@ Notices:
 * Unless expressly stated otherwise, the person who associated a work with this deed makes no warranties about the work, and disclaims liability for all uses of the work, to the fullest extent permitted by applicable law.
 * When using or citing the work, you should not imply endorsement by the author or the affirmer.
 
+## Software
+
+Copyright (c) 2025 SciLifeLab
+
+### The MIT License (MIT)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
 ## Terms of Service of SciLifeLab Data Stewardship Wizard
 
 ### Introduction
@@ -43,4 +67,3 @@ Certain features on this website utilize third party services and APIs, e.g., fo
 
 ### Revisions
 This statement was last revised on October 07, 2020 and may be revised at any time. Use of the tool indicates that you understand and fully agree to these terms and conditions. Getting acquainted with current version of these terms as well as checking for its updates is the responsibility of every user.
-

--- a/README.md
+++ b/README.md
@@ -119,10 +119,6 @@ Once approved, they will be merged and deployed.
 
 If in doubt, you can ask for help by emailing [data-management@scilifelab.se](mailto:data-management@scilifelab.se).
 
-## License
-
-The content documents are dedicated to the public domain under a CC-0 license.
-
 ## Credits
 
 The website was built by [SciLifeLab Data Centre](https://www.scilifelab.se/data/) and [NBIS](https://nbis.se/).


### PR DESCRIPTION
- The contents are covered by the Creative Commons license but the MIT license is for any software/code components.
- The code here in this repo is minimal but safer to have it.

**Question: whilst I was in there, I saw that the version of the Creative Commons license is quite old - possibly should be updated**