### PR TITLE
setup tracking with matomo for hugo site

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>Data Stewardship Wizard</title>
     <link href="/css/styles.css" rel="stylesheet">
+    <script src="/js/matomo_setup.js"></script>
   </head>
   <body>
     <!-- Load header navbar -->

--- a/static/js/matomo_setup.js
+++ b/static/js/matomo_setup.js
@@ -1,0 +1,12 @@
+var _paq = window._paq = window._paq || [];
+_paq.push(['setDocumentTitle', location.hostname + "/" + document.title]);
+_paq.push(['trackPageView']);
+_paq.push(['enableLinkTracking']);
+(function() {
+  var u="https://matomo.dc.scilifelab.se/";
+  _paq.push(['setTrackerUrl', u+'matomo.php']);
+  _paq.push(['setSiteId', '16']);
+  var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+  g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+})();
+


### PR DESCRIPTION
Hello,

This PR covers adding Matomo tracking code to the dsw-appendix site. The configuration on the Matomo side of things is already sorted and we plan to track both this site and https://dsw.scilifelab.se/wizard with the same Matomo `siteid`. 

I've added the tracking code at the end of the `<head>` as Matomo recommends. 

The JS snippet is the default provided by Matomo with 1 exception which is the addition of this line:
```js
_paq.push(['setDocumentTitle', location.hostname + "/" + document.title]);
// if not set it is just document.title
```

The reason for this is as follows: 
> if we track multiple subdomains on the same website, we may want our page titles to be prefixed by the sub-domain to make it easy to see the traffic and data for each sub-domain. In order to do so, please add the below changes:

Source: https://matomo.org/faq/how-to/how-do-i-set-a-custom-page-title-using-the-matomo-javascript-title/ 

If you click that link you may see that in their example for how to do this they use `document.domain` instead of `location.hostname` but [`document.domain` is depreciated ](https://developer.mozilla.org/en-US/docs/Web/API/Document/domain). I've validated `location.hostname` works nicely on the https://dsw.scilifelab.se sites. 

If you prefer to inline the script or make other changes etc... feel free, I have enabled edits. 

I ran hugo serve locally and could see POSTs going to https://matomo.dc.scilifelab.se/ with 204 responses so it seems to be working. 

(Lianne is aware about this.)